### PR TITLE
9-completes delete /api/comments/:comment_id endpoint

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -302,4 +302,31 @@ describe("PATCH 200, /api/articles/:article_id", () => {
         expect(body.msg).toBe("Not found");
       });
   });
+
+  describe("DELETE /api/comments/:comment_id", () => {
+    test("DELETE 204: will return correct error message and no body when given valid comment id", () => {
+      return request(app)
+        .delete("/api/comments/1")
+        .expect(204)
+        .then(({ body }) => {
+          expect(body).toEqual({});
+        });
+    });
+  });
+  test("DELETE 400: will return correct error message if given invalid comment id", () => {
+    return request(app)
+      .delete("/api/comments/XX")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Bad request");
+      });
+  });
+  test("DELETE 404: will return correct error message if given invalid comment id", () => {
+    return request(app)
+      .delete("/api/comments/999")
+      .expect(404)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Comment not found");
+      });
+  });
 });

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const {
   postArticleComment,
   patchArticleVotes
 } = require("./controllers/articles.controller");
+const { deleteCommentById } = require("./controllers/comments.controller")
 
 const express = require("express");
 const app = express();
@@ -26,6 +27,8 @@ app.get("/api/articles/:article_id/comments", getArticleComments);
 app.post("/api/articles/:article_id/comments", postArticleComment);
 
 app.patch("/api/articles/:article_id", patchArticleVotes)
+
+app.delete("/api/comments/:comment_id", deleteCommentById)
 
 app.use((err, req, res, next) => {
   if (err.code) {

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,0 +1,14 @@
+const { removeCommentById } = require("../models/comments.model");
+
+const deleteCommentById = (req, res, next) => {
+  const commentId = req.params.comment_id;
+  removeCommentById(commentId)
+    .then((result) => {
+      return res.status(204).send({});
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+module.exports = { deleteCommentById };

--- a/endpoints.json
+++ b/endpoints.json
@@ -62,5 +62,10 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+  "DELETE /api/comments/:comment_id": {
+    "description": "deletes a comment by comment_id",
+    "queries": [],
+    "exampleResponse": {}
   }
 }

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -1,0 +1,17 @@
+const db = require("../db/connection");
+
+const removeCommentById = (commentId) => {
+  return db
+    .query(
+      `DELETE FROM comments WHERE comment_id =$1 RETURNING body`,
+      [commentId]
+    )
+    .then(({ rows }) => {
+      if (!rows.length) {
+        return Promise.reject({ status: 404, msg: "Comment not found" });
+      }
+      return rows;
+    });
+};
+
+module.exports = { removeCommentById };


### PR DESCRIPTION
completes task 9 deleting comments by comment_id with endpoint /api/comments/:comment_id with relevant tests and updated endpoint.json file. 